### PR TITLE
fix: use underscore in package name to match go mod naming

### DIFF
--- a/ddnswhitelist.go
+++ b/ddnswhitelist.go
@@ -1,5 +1,8 @@
-// Package ddnswhitelist dynamic DNS whitelist
-package ddnswhitelist
+// Package ddns_whitelist dynamic DNS whitelist
+//
+//revive:disable-next-line:var-naming
+//nolint:stylecheck
+package ddns_whitelist
 
 import (
 	"context"

--- a/ddnswhitelist_test.go
+++ b/ddnswhitelist_test.go
@@ -1,4 +1,6 @@
-package ddnswhitelist
+//revive:disable-next-line:var-naming
+//nolint:stylecheck
+package ddns_whitelist
 
 import (
 	"context"

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,9 @@
-// Package ddnswhitelist usesthis implementation to log messages
+// Package ddns_whitelist usesthis implementation to log messages
 // source: https://github.com/traefik/plugindemo/issues/22#issuecomment-2329608616
-package ddnswhitelist
+//
+//revive:disable-next-line:var-naming
+//nolint:stylecheck
+package ddns_whitelist
 
 import (
 	"fmt"


### PR DESCRIPTION
When the package does not match the module name Traefik can not load the plugin:

```log
traefik  | 2024-10-01T11:53:42Z ERR github.com/traefik/traefik/v3/cmd/traefik/traefik.go:240 > Plugins are disabled because an error has occurred. error="failed to eval New: 1:28: undefined: ddns_whitelist" plugins=["ddns-whitelist"]
```