### PR TITLE
chore: use best practice plugin name in examples

### DIFF
--- a/examples/k8s/resources/allow.yml
+++ b/examples/k8s/resources/allow.yml
@@ -4,7 +4,7 @@ metadata:
   name: ddnswhitelist-allow
 spec:
   plugin:
-    ddnsWhitelist:
+    ddns-whitelist:
       hostList:
       - localhost
 ---

--- a/examples/k8s/resources/deny.yml
+++ b/examples/k8s/resources/deny.yml
@@ -4,7 +4,7 @@ metadata:
   name: ddnswhitelist-deny
 spec:
   plugin:
-    ddnsWhitelist:
+    ddns-whitelist:
       hostList:
       - dns.google
 ---

--- a/examples/k8s/traefik-values.yml
+++ b/examples/k8s/traefik-values.yml
@@ -1,9 +1,9 @@
 # Traefik installation with DDNS whitelist plugin
 experimental:
   plugins:
-    ddnsWhitelist:
-      moduleName: github.com/taskmedia/ddns-whitelist
-      version: v1.1.1
+    ddns-whitelist:
+      moduleName: "github.com/taskmedia/ddns-whitelist"
+      version: v2.0.0
 
 globalArguments:
 - "--global.checknewversion=false"


### PR DESCRIPTION
use best practice plugin name in examples