### PR TITLE
chore: improve log output

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -7,6 +7,7 @@ import: github.com/taskmedia/ddns-whitelist
 summary: 'A middleware that allows you to whitelist on a dynamic DNS'
 
 testData:
+  logLevel: ERROR
   hostList:
   - my.router.ddns.tld
   ipList:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ http:
     ddns-whitelist-router:
       plugin:
         ddns-whitelist:
+          logLevel: ERROR
           hostList: # hosts to dynamically whitelist via DNS lookup
             - my.router.ddns.tld
           ipList: # optional IP addresses to whitelist

--- a/ddnswhitelist.go
+++ b/ddnswhitelist.go
@@ -29,6 +29,7 @@ var (
 
 // Config the plugin configuration.
 type Config struct {
+	LogLevel string   `json:"logLevel,omitempty"` // Log level (DEBUG, INFO, ERROR)
 	HostList []string `json:"hostList,omitempty"` // Add hosts to whitelist
 	IPList   []string `json:"ipList,omitempty"`   // Add additional IP addresses to whitelist
 }
@@ -53,7 +54,7 @@ type ddnswhitelist struct {
 
 // New created a new DDNSwhitelist plugin.
 func New(_ context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
-	log := newLogger("debug", name, typeName)
+	log := newLogger(config.LogLevel, name, typeName)
 	log.Debug("Creating middleware")
 
 	if len(config.HostList) == 0 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: "traefik:v3.1"
+    image: "traefik:v3.1.4"
     container_name: "traefik"
     command:
     - "--log.level=DEBUG"

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,8 @@
 // Package ddns_whitelist usesthis implementation to log messages
 // source: https://github.com/traefik/plugindemo/issues/22#issuecomment-2329608616
 //
+// Hint: does not support other log formats (e.g. json) than the default common
+//
 //revive:disable-next-line:var-naming
 //nolint:stylecheck
 package ddns_whitelist
@@ -8,7 +10,15 @@ package ddns_whitelist
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
+	"time"
+)
+
+const (
+	// prefixDebug = "DBG"
+	prefixInfo = "INF"
+	// prefixError = "ERR"
 )
 
 // Logger will log messages with context.
@@ -37,7 +47,8 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 			fmt.Println(args...)
 		},
 		_info: func(args ...interface{}) {
-			fmt.Println(args...)
+			prefixArgs := append([]interface{}{getTimestamp(), prefixInfo, ">"}, args...)
+			log.New(os.Stdout, "", 0).Println(prefixArgs...)
 		},
 		_error: func(args ...interface{}) {
 			log.Println(args...)
@@ -46,7 +57,8 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 			fmt.Printf(format+"\n", args...)
 		},
 		_infof: func(format string, args ...interface{}) {
-			fmt.Printf(format+"\n", args...)
+			f := getTimestamp() + " " + prefixInfo + " > " + format
+			log.New(os.Stdout, "", 0).Printf(f, args...)
 		},
 		_errorf: func(format string, args ...interface{}) {
 			log.Printf(format+"\n", args...)
@@ -75,6 +87,10 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 	}
 
 	return logger
+}
+
+func getTimestamp() string {
+	return time.Now().Format(time.RFC3339)
 }
 
 func (l *Logger) logWithContext(logFunc func(args ...interface{}), args ...interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -17,7 +17,10 @@ import (
 
 const (
 	// prefixDebug = "DBG"
-	prefixInfo = "INF"
+	prefixInfo = colorGreen + "INF" + colorReset
+	colorReset = "\033[0m"
+	colorGray  = "\033[90m"
+	colorGreen = "\033[32m"
 	// prefixError = "ERR"
 )
 
@@ -90,7 +93,7 @@ func newLogger(_logLevel, middleware, middlewareType string) *Logger {
 }
 
 func getTimestamp() string {
-	return time.Now().Format(time.RFC3339)
+	return colorGray + time.Now().Format(time.RFC3339) + colorReset
 }
 
 func (l *Logger) logWithContext(logFunc func(args ...interface{}), args ...interface{}) {


### PR DESCRIPTION
Improve logging for plugin.

Not that easy to find a good logging for a Traefik plugin..

The `traefik/traefik` default package for logging is `github.com/rs/zerolog/log`. But unfortunately this can not be used because [yaegi](https://github.com/traefik/yaegi) (go interpreter used for plugins) does not allow anything from `unsafe` which results in a error.

When having a look at many other Traefik plugins everyone seems to use an other approach. All implementations do not feel pleasant for me.
Therefore I extended and modified the current implementation (based on https://github.com/traefik/plugindemo/issues/22#issuecomment-2329608616). Now there is a format as the common (not json) format as Traefik uses.

This current implementation uses these methods to log:

- **debug**: `fmt.Println()`
- **info**: `log.New(os.Stdout, "", 0).Println()` with custom templating
- **error**: `log.Println()`

Both, debug and error, implementation will be collected automatically by Traefik and result in their logging format.
Other log levels can not be forwarded - therefore the info uses Stdout log to template the log message in total.
If required other levels e.g. warning could be implemented the same way.

Because the logLevel can not be obtained from Traefik it now can be specified my the plugin configuration (default: error).